### PR TITLE
4-duplicate-servers-appearing-in-api-response

### DIFF
--- a/sc4mpapi.py
+++ b/sc4mpapi.py
@@ -288,6 +288,11 @@ class Scanner(Thread):
 					entry["version"] = server_version
 					entry["updated"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
 
+					# Only add server if we got a valid server_id
+					if not server_id:
+						print(f"[WARNING] Server at {self.server[0]}:{self.server[1]} failed to get server ID, skipping.")
+						return
+
 					self.parent.new_servers.setdefault(server_id, entry)
 
 					# Fetch server data using appropriate protocol


### PR DESCRIPTION
## Summary
- Fixed duplicate servers appearing in API response by validating server_id before adding to dictionary
- Servers with empty/None server_id (from failed protocol detection) are now skipped with a warning message
- Prevents duplicate entries with invalid keys in the server list

## Test plan
- [ ] Deploy changes to production
- [ ] Monitor `/servers` endpoint for duplicate entries
- [ ] Verify warning messages appear in logs when server_id fetch fails
- [ ] Confirm all valid servers still appear correctly in API response

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)